### PR TITLE
Fix Uncaught ReferenceError: module is not defined

### DIFF
--- a/tsmonad.ts
+++ b/tsmonad.ts
@@ -20,7 +20,7 @@ declare module 'tsmonad' {
 (function () {
     'use strict';
 
-    if (typeof module !== undefined && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         // it's node
         module.exports = TsMonad;
     } else {


### PR DESCRIPTION
This line was causing browsers to raise Uncaught ReferenceError: module is not defined
