### PR TITLE
hotfix: Correct dts header 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,6 @@ module.exports = function (grunt) {
         banner: '// Type definitions for TsMonad\n' +
                 '// Project: https://github.com/cbowdon/TsMonad\n' +
                 '// Definitions by: Chris Bowdon <https://github.com/cbowdon>\n' +
-                '// Definitions by: Valentin Trinque <https://github.com/ValentinTrinque>\n' +
                 '// Definitions: https://github.com/borisyankov/DefinitelyTyped\n',
         usebanner: {
             dts: {

--- a/dist/tsmonad.d.ts
+++ b/dist/tsmonad.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for TsMonad
 // Project: https://github.com/cbowdon/TsMonad
 // Definitions by: Chris Bowdon <https://github.com/cbowdon>
-// Definitions by: Valentin Trinque <https://github.com/ValentinTrinque>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module TsMonad {


### PR DESCRIPTION
Removal of a double definition of `Definitions by:` in the `Gruntfile.js` because it's not supported by DefinitelyTyped.

An error is raised when executing `npm test` (aiming to verify the correctness of the dts file) on the DefinitelyTyped repository.
