### PR TITLE
Support typings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "TsMonad - fun-size monads library for TypeScript",
   "main": "dist/tsmonad.js",
+  "typings": "dist/tsmonad.d.ts",
   "files": [ "dist", "*.ts", "LICENSE-MIT", "README.md" ],
   "directories": {},
   "scripts": {


### PR DESCRIPTION
This allows users to automatically detect the typings by tsc, even if node_modules is excluded.

https://github.com/Microsoft/TypeScript/issues/4925
https://github.com/Microsoft/TypeScript/wiki/Typings-for-npm-packages
