### PR TITLE
Add an npm build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [ "dist", "*.ts", "LICENSE-MIT", "README.md" ],
   "directories": {},
   "scripts": {
+    "build": "grunt",
     "test": "echo \"Please open test/index.html in your browser\" && exit 0"
   },
   "repository": {


### PR DESCRIPTION
All npm packages use scripts and contributors know where to look.
Grunt, however, is a package-specific implementation detail.
