### PR TITLE
make properties protected instead of private to allow class extensions

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -82,9 +82,9 @@ export class Either<L,R> implements Monad<R>, Functor<R>, Eq<Either<L,R>> {
      * @param {L} l The Left value (optional).
      * @param {R} l The Right value (optional).
      */
-    constructor(private type: EitherType,
-                private l?: L,
-                private r?: R) {}
+    constructor(protected type: EitherType,
+                protected l?: L,
+                protected r?: R) {}
 
     /**
      * @name left

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -63,8 +63,8 @@ export class Maybe<T> implements Monad<T>, Functor<T>, Eq<Maybe<T>> {
      * @param {MaybeType} type Indicates if the Maybe content is a Just or a Nothing.
      * @param {T} value The value to wrap (optional).
      */
-    constructor(private type: MaybeType,
-                private value?: T) {}
+    constructor(protected type: MaybeType,
+                protected value?: T) {}
 
     /**
      * @name sequence

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -44,7 +44,7 @@ export class Writer<S,T> implements Monad<T>, Eq<Writer<S,T>> {
      * @param {S[]} story The collection of logs.
      * @param {T} value The object to wrap.
      */
-    constructor(private story: S[], private value: T) {}
+    constructor(protected story: S[], protected value: T) {}
 
     /**
      * @name writer


### PR DESCRIPTION
I though of extending your library with some helper functions, like extending the `Maybe` and add a `or(fn: () => Maybe<T>): Maybe<T>`. This is not easily possible right now since `type` and `value` are private.
