### PR TITLE
Add typings section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublish": "npm run build",
     "test": "mocha lib/test"
   },
+  "typings": "dist/tsmonad.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/cbowdon/TsMonad.git"


### PR DESCRIPTION
Typings section should point to built definition file.

Now if I install `tsmonad` in empty node project with `"noImplicitAny": true` I'll see `error TS7016: Could not find a declaration file for module 'tsmonad'. '/Users/pavelbirukov/work/tsplayground/node_modules/tsmonad/dist/tsmonad.js' im
plicitly has an 'any' type.`

Thus looking at tsc's [module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html) it's necessary to either have `index.ts` in root directory or have `typings` section which points to definition file