### PR TITLE
Use TypeScript's Partial<T>

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -29,10 +29,7 @@ export interface EitherPatterns<L,R,T> {
 }
 
 // ditto, but optional
-export interface OptionalEitherPatterns<L,R,T> {
-    left?: (l: L) => T;
-    right?: (r: R) => T;
-}
+export type OptionalEitherPatterns<L,R,T> = Partial<EitherPatterns<L,R,T>>
 
 function exists<T>(t: T) {
     return t !== null && t !== undefined;
@@ -234,12 +231,12 @@ export class Either<L,R> implements Monad<R>, Functor<R>, Eq<Either<L,R>> {
      *     original value, so is meant for running functions with side-effects.
      * @methodOf Either#
      * @public
-     * @param {OptionalEitherPatterns<T, U>} pattern Object containing the
+     * @param {Partial<EitherPatterns<T, U>>} pattern Object containing the
      *     functions to applied on each Either type.
      * @return The original Either value.
-     * @see OptionalEitherPatterns#
+     * @see EitherPatterns#
      */
-    do(patterns: OptionalEitherPatterns<L, R, void> = {}): Either<L, R> {
+    do(patterns: Partial<EitherPatterns<L, R, void>> = {}): Either<L, R> {
         let noop_pattern = {
             left: (l: L) => {},
             right: (r: R) => {},

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -30,10 +30,7 @@ export interface MaybePatterns<T,U> {
 }
 
 // ditto, but optional
-export interface OptionalMaybePatterns<T,U> {
-    just?: (t: T) => U;
-    nothing?: () => U;
-}
+export type OptionalMaybePatterns<T,U> = Partial<MaybePatterns<T,U>>
 
 /**
  * @name maybe
@@ -319,12 +316,12 @@ export class Maybe<T> implements Monad<T>, Functor<T>, Eq<Maybe<T>> {
      *     original value, so is meant for running functions with side-effects.
      * @methodOf Maybe#
      * @public
-     * @param {OptionalMaybePatterns<T, U>} pattern Object containing the
+     * @param {Partial<MaybePatterns<T, U>>} pattern Object containing the
      *     functions to applied on each Maybe type.
      * @return The original Maybe value.
-     * @see OptionalMaybePatterns#
+     * @see MaybePatterns#
      */
-    do(patterns: OptionalMaybePatterns<T, void> = {}): Maybe<T> {
+    do(patterns: Partial<MaybePatterns<T, void>> = {}): Maybe<T> {
         let noop_pattern = {
             just: (t: T) => {},
             nothing: () => {},


### PR DESCRIPTION
Instead of manually making keys optional.

Keeps exporting the `Optional*` types for backwards compatibility