### PR TITLE
chore(Maybe): Upgrade the typing for maybe.sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ user.getLikesCookies().valueOrCompute(() => expensiveCalculation());
 user.getLikesCookies().valueOrThrow(new Error());
 
 // Maybe.just({ three: 3, hi: 'hi'})
-Maybe.sequence<number|string>({ three: Maybe.just(3), hi: Maybe.just('hi') });
+Maybe.sequence({ three: Maybe.just(3), hi: Maybe.just('hi') });
 
 // Maybe.nothing
-Maybe.sequence<number>({ three: Maybe.just(3), hi: Maybe.nothing() });
+Maybe.sequence{ three: Maybe.just(3), hi: Maybe.nothing() });
 ```
 
 ### General Either usage

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -71,17 +71,17 @@ export class Maybe<T> implements Monad<T>, Functor<T>, Eq<Maybe<T>> {
      * @param {{[id: string]: Maybe<T>}} t The value to unwrap Maybe values from.
      * @returns {Maybe<{[id: string]: T}>} A Maybe object containing the value passed in input with fields unwrapped from Maybes.
      */
-    static sequence<T>(t: {[k: string]: Maybe<T>}): Maybe<{[k: string]: T}> {
-        if (Object.keys(t).filter(k => t[k].type === MaybeType.Nothing).length) {
-            return Maybe.nothing<{[k: string]: T}>();
+    static sequence<T extends object>(t: {[k in keyof T]: Maybe<T[k]>}): Maybe<{[k in keyof T]: T[k]}> {
+        if ((Object.keys(t) as Array<keyof T>).filter(k => t[k].type === MaybeType.Nothing).length) {
+            return Maybe.nothing<T>();
         }
-        var result: {[k: string]: any} = {};
+        var result: Partial<T> = {};
         for (var k in t) {
             if (t.hasOwnProperty(k)) {
                 result[k] = t[k].value;
             }
         }
-        return Maybe.just(result);
+        return Maybe.just(result as T);
     }
 
     /**
@@ -91,7 +91,7 @@ export class Maybe<T> implements Monad<T>, Functor<T>, Eq<Maybe<T>> {
      * @static
      * @see Maybe#sequence
      */
-    static all = (t: {[k: string]: Maybe<any>}) => Maybe.sequence<any>(t);
+    static all = <T extends object>(t: {[k in keyof T]: Maybe<T[k]>}) => Maybe.sequence<any>(t);
 
     /**
      * @name maybe

--- a/test/maybe.ts
+++ b/test/maybe.ts
@@ -171,7 +171,7 @@ describe('Maybe', () => {
             nothing: () => false
         }));
 
-        assert.ok(Maybe.sequence<string|number>({
+        assert.ok(Maybe.sequence({
             num: Maybe.just(10),
             str: Maybe.just('union types')
         }).caseOf({
@@ -179,7 +179,7 @@ describe('Maybe', () => {
             nothing: () => false
         }));
 
-        assert.ok(Maybe.sequence<any>({
+        assert.ok(Maybe.sequence({
             num: Maybe.just(10),
             str: Maybe.just('dynamic types')
         }).caseOf({


### PR DESCRIPTION
We would like to have a better typing of sequence such that when we use sequence we get returned a typing with same informational entropy as what was inputed.
Example type difference
```
from: typeof sequence({ a1: Monad<A>, a2: Monad<A> }) === Monad<{ [string]: A }>
to: typeof sequence({ a1: Monad<A>, a2: Monad<A> }) === Monad<{ a1: A, a2: A}>
```
and
```
from: typeof sequence<A | B>({ a: Monad<A>, b: Monad<B> }) === Monad<{ [string]: A | B }>
to: typeof sequence({ a: Monad<A>, b: Monad<B> }) === Monad<{ a: A, b: B}>
```

Breaking: Previous typings that specified the generic for funciton of all or sequence will fail.