### PR TITLE
Added `run` function imitating "do-notation".

### DIFF
--- a/test/maybe.ts
+++ b/test/maybe.ts
@@ -10,18 +10,27 @@ describe('Maybe', () => {
         const bJust = Maybe.just("2");
         const bNothing = Maybe.nothing<number>();
 
+        assert.ok(Maybe.run(function* () {
+            const x = yield a;
+            const y = yield bJust;
+            return x + parseInt(y); // return a "normal" value
+        }).caseOf({
+            just: x => x === 3,
+            nothing: () => false
+        }));
+
         assert.ok(Maybe.run<number>(function* () {
-            let x = yield a;
-            let y = yield bJust;
-            return x + parseInt(y);
+            const x = yield a;
+            const y = yield bJust;
+            return Maybe.maybe(x + parseInt(y)); // explicitly return a Maybe<T>
         }).caseOf({
             just: x => x === 3,
             nothing: () => false
         }));
 
         assert.ok(Maybe.run(function* () {
-            let x = yield a;
-            let y = yield bNothing;
+            const x = yield a;
+            const y = yield bNothing;
             return x + y;
         }).caseOf({
             just: x => false,

--- a/test/maybe.ts
+++ b/test/maybe.ts
@@ -5,6 +5,30 @@ import * as assert from 'assert'
 
 describe('Maybe', () => {
 
+    it('Run', () => {
+        const a = Maybe.just(1);
+        const bJust = Maybe.just("2");
+        const bNothing = Maybe.nothing<number>();
+
+        assert.ok(Maybe.run<number>(function* () {
+            let x = yield a;
+            let y = yield bJust;
+            return x + parseInt(y);
+        }).caseOf({
+            just: x => x === 3,
+            nothing: () => false
+        }));
+
+        assert.ok(Maybe.run(function* () {
+            let x = yield a;
+            let y = yield bNothing;
+            return x + y;
+        }).caseOf({
+            just: x => false,
+            nothing: () => true
+        }));
+    });
+
     it('Case of', () => {
 
         assert.ok(Maybe.just(10)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "moduleResolution": "node",
         "isolatedModules": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@types/mocha@^2.2.40":
+  version "2.2.48"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
+
+"@types/node@^7.0.12":
+  version "7.0.70"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.70.tgz#688aaeb6e6d374ed016c4dc2c46de695859d6887"
+
+"@types/underscore@^1.8.0":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.9.tgz#fef41f800cd23db1b4f262ddefe49cd952d82323"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -1286,9 +1298,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@^1.8.10:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
+typescript@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
 uglify-js@~2.7.3:
   version "2.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/mocha@^2.2.40":
-  version "2.2.48"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
-
-"@types/node@^7.0.12":
-  version "7.0.70"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.70.tgz#688aaeb6e6d374ed016c4dc2c46de695859d6887"
-
-"@types/underscore@^1.8.0":
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.9.tgz#fef41f800cd23db1b4f262ddefe49cd952d82323"
-
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -1298,9 +1286,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
+typescript@^1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
 
 uglify-js@~2.7.3:
   version "2.7.5"


### PR DESCRIPTION
This PR adds a function called `run` that imitates Haskell's do-notation, as inspired by  [this blogpost](https://codewithstyle.info/advanced-functional-programming-typescript-monads-generators/). This implemented version here is slightly different to make it nicer-to-use. This implementation accepts returning `Maybe<T>` or just `T` from the generator function.

This example is also implemented as a unit test but for clarification, this PR adds the possibility to do the following:
```
const result: Maybe<number> = Maybe.run<number>(function* () {
  const x = yield Maybe.just(1);
  const y = yield Maybe.just("2");
  return x + parseInt(y);
});
```

Without the `run` function, this example could be solved using `sequence` or using a combination of `.bind().map()`, which doesn't scale in terms of indentation. Using `sequence` seems like an odd solution in this case as it's not particularly natural to represent these values in a map.
```
const result: Maybe<number> = Maybe.just(1).bind((x) => {
    return Maybe.just("2").map((y) => {
        return x + parseInt(y);
    })
});
```

Note though that the variables within the generator function (e.g. in above example `const x`) will be of type `any`, but any mixture of types within `Maybe<T>` is accepted (e.g. in above example `Maybe<number>` and `Maybe<string>`